### PR TITLE
PV and PVC plugin changes to support snapshots

### DIFF
--- a/velero-plugins/migpv/restore.go
+++ b/velero-plugins/migpv/restore.go
@@ -32,8 +32,12 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	p.Log.Infof("[pv-restore] pv: %s", pv.Name)
 
 	if pv.Annotations[migcommon.MigrateTypeAnnotation] == "copy" {
-		p.Log.Infof("[pv-restore] Not a swing PV migration. Skipping pv restore, %s.", pv.Name)
-		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+		p.Log.Infof("[pv-restore] Setting storage class, %s.", pv.Name)
+		storageClassName := pv.Annotations[migcommon.MigrateStorageClassAnnotation]
+		pv.Spec.StorageClassName = storageClassName
+		if storageClassName != "" && pv.Annotations[corev1API.BetaStorageClassAnnotation] != "" {
+			pv.Annotations[corev1API.BetaStorageClassAnnotation] = storageClassName
+		}
 	}
 
 	var out map[string]interface{}

--- a/velero-plugins/migpvc/restore.go
+++ b/velero-plugins/migpvc/restore.go
@@ -34,10 +34,6 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	// Use default behavior (restore the PV) for a swing migration.
 	// For copy we remove annotations and PV volumeName
 	if pvc.Annotations[migcommon.MigrateTypeAnnotation] == "copy" {
-		p.Log.Info("[pvc-restore] Removing PV specific information since we are copying")
-		pvc.Spec.VolumeName = ""
-		delete(pvc.Annotations, "pv.kubernetes.io/bind-completed")
-		delete(pvc.Annotations, "pv.kubernetes.io/bound-by-controller")
 
 		// ISSUE-61 : removing the label selectors from PVC's
 		// to avoid PV dynamic provisioner getting stuck


### PR DESCRIPTION
Add copy by snapshot support:
1) Don't discard PV on restore
     We need it for snapshots, and velero already
     discards it for restic
2) Change storageclass name for PV as well as PVC
3) Drop the VolumeName and bind annotation removal for PVC
     For snapshots we need this, and for restic
     leaving them doesn't break anything