### PR TITLE
[WIP] Add MigPlan-based labels to restore

### DIFF
--- a/velero-plugins/migcommon/restore.go
+++ b/velero-plugins/migcommon/restore.go
@@ -43,11 +43,16 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		if !exist {
 			return nil, errors.New("migmigration label is not found on restore")
 		}
+		migPlanLabel, exist := input.Restore.Labels[MigPlanLabelKey]
+		if !exist {
+			p.Log.Warn("migplan label is not found on restore")
+		}
 		labels := metadata.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
 		labels[MigratedByLabel] = migMigrationLabel
+		labels[MigPlanLabelKey] = migPlanLabel
 		metadata.SetLabels(labels)
 	}
 

--- a/velero-plugins/migcommon/types.go
+++ b/velero-plugins/migcommon/types.go
@@ -38,4 +38,5 @@ const NamespaceSCCAnnotationUidRange string = "openshift.io/sa.scc.uid-range"
 
 // Restored items label
 const MigMigrationLabelKey string = "migmigration"
+const MigPlanLabelKey string = "migration.openshift.io/migplan-ref"
 const MigratedByLabel string = "migration.openshift.io/migrated-by" // (migmigration UID)


### PR DESCRIPTION
In order to allow Rollback operation by a migmigration following after other migmigration
perfomed the migration operation, it is needed label restored objects by MigPlan to allow
identify such objects by the later created rollback migmigration.

Related to https://github.com/konveyor/mig-controller/pull/677
Related to https://github.com/konveyor/mig-controller/issues/663